### PR TITLE
Fix format mismatch to the word template *bold sonti and heiti*

### DIFF
--- a/fontname.def
+++ b/fontname.def
@@ -2,8 +2,8 @@
 \setCJKmainfont[BoldFont={SimHei},ItalicFont={KaiTi}]{SimSun}
 \setCJKsansfont{SimHei}
 \setCJKmonofont{FangSong}
-\setCJKfamilyfont{zhsong}{SimSun}
-\setCJKfamilyfont{zhhei}{SimHei}
+\setCJKfamilyfont{zhsong}[AutoFakeBold = {1.5}]{SimSun}
+\setCJKfamilyfont{zhhei}[AutoFakeBold = {1.5}]{SimHei}
 \setCJKfamilyfont{zhkai}{KaiTi}
 \setCJKfamilyfont{zhfs}{FangSong}
 

--- a/ucasthesis.cls
+++ b/ucasthesis.cls
@@ -565,17 +565,17 @@
       \ifucas@secret\hfill{\sihao[1]\songti 密级：\ulenhance[1pt]{\makebox[6em]{\ucas@secretcontent}}}\fi}
       \begin{figure}[H]
         \centering
-        \includegraphics[width=90mm]{ucaslogo}
+        \includegraphics[width=104.3mm]{ucaslogo}
       \end{figure}
       \parbox[t][6cm][t]{\paperwidth-8cm}{
       \renewcommand{\baselinestretch}{1.3}
       \begin{center}
       \yihao\heiti\textbf{\ucas@apply}
       \par\vskip 40bp
-      \xiaosan\rmfamily\textbf{\ulenhance[1.2pt]{\ucas@ctitle}}
+      \xiaosan\heiti\textbf{\ulenhance[1.2pt]{\ucas@ctitle}}
       \end{center}}
 
-\parbox[t][9cm][t]{\textwidth}{{\sihao\rmfamily\bfseries
+\parbox[t][9cm][t]{\textwidth}{{\sihao\songti\bfseries
 \begin{center}
 \setlength{\ucas@title@width}{4em}
 \setlength{\extrarowheight}{2.5ex}
@@ -598,7 +598,7 @@
 
 }
   \begin{center}
-    {\vskip 3ex\sihao \bfseries\rmfamily \ucas@cdate}
+    {\vskip 3ex\sihao\songti \bfseries \ucas@cdate}
   \end{center}
 \end{center}} % end of titlepage
 \newcommand{\ucas@engcover}{%


### PR DESCRIPTION
修正封面中几处格式问题：
（1）UcasLogo大小调大，与模板中图片大小一致；
（2）“博士/硕士”学位论文需要加粗；
（3）“作者姓名”等改为加粗宋体。

这里加粗使用了1.5倍自动加粗，参考了如下链接：
https://blog.csdn.net/songyuc/article/details/80271607